### PR TITLE
Fix Sonar run failing on PR builders

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,23 @@
         <jacoco.plugin.version>0.7.2.201409121644</jacoco.plugin.version>
     </properties>
 
+    <profiles>
+        <profile>
+            <id>sonar</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <properties>
+                <sonar.exclusions>
+                    target/**
+                </sonar.exclusions>
+                <sonar.inclusions>
+                    pom.xml
+                </sonar.inclusions>
+            </properties>
+        </profile>
+    </profiles>
+
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
Sonar run fails when pull requests do not change the pom.xml file. This change fixes this.