### PR TITLE
Removing "internal" from description.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # certified-devkit-parent-pom
-Internal Parent POM for certified connector projects.
+Parent POM for certified connector projects.


### PR DESCRIPTION
Removing "internal" from the description as this will be used by partners as well.