### PR TITLE
W-10921710: Bump version of mule-devkit-parent to 3.9.16 and change v…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,17 +12,17 @@
         <connection>scm:git:git://github.com:mulesoft/certified-mule-connector-parent.git</connection>
         <developerConnection>scm:git:git@github.com:mulesoft/certified-mule-connector-parent.git</developerConnection>
         <url>http://github.com/mulesoft/certified-mule-connector-parent</url>
-        <tag>certified-mule-connector-parent-3.9.13</tag>
+        <tag>certified-mule-connector-parent-3.9.16</tag>
     </scm>
 
     <parent>
         <groupId>org.mule.tools.devkit</groupId>
         <artifactId>mule-devkit-parent</artifactId>
-        <version>3.9.14</version>
+        <version>3.9.16</version>
     </parent>
 
     <artifactId>certified-mule-connector-parent</artifactId>
-    <version>3.9.14-SNAPSHOT</version>
+    <version>3.9.16-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>


### PR DESCRIPTION
…ersion to 3.9.16-SNAPSHOT

Changing parent pom addresses log4j vulnerability (2.12.4)